### PR TITLE
Add elevation-aware wind report

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Using a reverse proxy such as Nginx, configure the following:
   - GET `/api/timezone` ➡ `http://api.timezonedb.com/v2.1/get-time-zone` (You will need to attach an API key. Note: This API is only used as a fallback for when the `/api/weather` endpoint fails.)
   - GET `/api/aviationweather` ➡ `https://www.aviationweather.gov/adds/dataserver_current/httpparam`
   - GET `/api/weather/{proxy+}` ➡ `https://api.weather.gov/{proxy}` Greedy path capturing, forwards to api.weather.gov.
+  - GET `/api/pqs` ➡ `https://nationalmap.gov/epqs/pqs.php` Get United States altitude information for a given geolocation.
+  - GET `/api/googleelevation` ➡ `https://maps.googleapis.com/maps/api/elevation/json` Get global altitude information for a given geolocation (backup API).
 - **IMPORTANT!** For each outgoing API request, make sure to:
   - Attach a `User-Agent` header, as per [NOAA](https://www.weather.gov/documentation/services-web-api) and [Nominatim](https://operations.osmfoundation.org/policies/nominatim/) usage policies.
   - **Keep these free APIs free - be a good API consumer!** Add caching for each route - I recommend at least 10 minutes for `rucsoundings.noaa.gov`, and one week for `nominatim.openstreetmap.org`.

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>PPG.report</title>
+    <title>PPG.report — Weather Report for Paramotor Pilots</title>
 
     <style>
       html {
@@ -178,7 +178,7 @@
     <meta property="og:title" content="PPG.report" />
     <meta
       property="og:description"
-      content="Weather report for Paramotor Pilots"
+      content="Weather report tailored for paramotor pilots. Combines NOAA rapid refresh Op40 analysis, nearby Terminal Aerodrome Forecasts, NWS hourly forecast for 2.5km grid areas and NWS active alerts."
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -189,7 +189,7 @@
     <meta name="twitter:title" content="PPG.report" />
     <meta
       name="twitter:description"
-      content="Weather report for Paramotor Pilots"
+      content="Weather report tailored for paramotor pilots. Combines NOAA rapid refresh Op40 analysis, nearby Terminal Aerodrome Forecasts, NWS hourly forecast for 2.5km grid areas and NWS active alerts."
     />
     <meta name="twitter:image" content="https://ppg.report/share.png" />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled/macro";
 import Footer from "./Footer";
 import WebHeader from "./header/web/Header";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import AppHeader from "./header/app/Header";
 import Routes from "./Routes";
 import HeaderRoutes from "./header/web/HeaderRoutes";
@@ -48,6 +48,9 @@ const Main = styled.main`
 `;
 
 function App() {
+  // Disable iOS swipe navigation when installed
+  const Router = isInstalled() ? MemoryRouter : BrowserRouter;
+
   return (
     <Router>
       <Global

--- a/src/features/geocode/ReverseLocation.tsx
+++ b/src/features/geocode/ReverseLocation.tsx
@@ -59,7 +59,7 @@ export default function ReverseLocation({ lat, lon }: ReverseLocationProps) {
 function generatePageTitle(pageName?: string | undefined): string {
   const appName = "PPG.report";
 
-  if (!pageName) return appName;
+  if (!pageName) return `${appName} — Weather Report for Paramotor Pilots`;
 
   return `${pageName} - ${appName}`;
 }

--- a/src/features/rap/CinCape.tsx
+++ b/src/features/rap/CinCape.tsx
@@ -92,6 +92,7 @@ export default function CinCape({ cin, cape }: CinCapeProps) {
           </Description>
         }
         interactive
+        placement="bottom"
       >
         <Cin cin={cin}>
           <h4>CIN</h4>
@@ -129,6 +130,7 @@ export default function CinCape({ cin, cape }: CinCapeProps) {
           </Description>
         }
         interactive
+        placement="bottom"
       >
         <Cape cape={cape}>
           <h4>CAPE</h4>

--- a/src/features/rap/Hours.tsx
+++ b/src/features/rap/Hours.tsx
@@ -8,6 +8,8 @@ import roundedScrollbar from "./roundedScrollbar";
 import { css } from "@emotion/react/macro";
 import throttle from "lodash/throttle";
 import { Rap } from "gsl-parser";
+import PointInfo from "./PointInfo";
+import ReportElevationDiscrepancy from "./ReportElevationDiscrepancy";
 
 const browser = detect();
 
@@ -114,6 +116,30 @@ const StyledHour = styled(Hour)`
 
     return css;
   }}
+`;
+
+const Footer = styled.div`
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 calc(var(--left-safe-area) + 1rem) 0
+    calc(var(--right-safe-area) + 1rem);
+
+  color: var(--softText);
+  font-size: 0.8em;
+  text-align: right;
+
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: 700px) {
+    text-align: center;
+
+    > *:not(:last-child):after {
+      content: "–";
+      display: block;
+    }
+  }
 `;
 
 interface TableProps {
@@ -273,6 +299,8 @@ export default function Hours({ rap }: TableProps) {
 
   return (
     <>
+      <ReportElevationDiscrepancy />
+
       <Container ref={scrollViewRef}>
         <ScrollContainer>
           <Nav
@@ -291,7 +319,10 @@ export default function Hours({ rap }: TableProps) {
         </ScrollContainer>
       </Container>
 
-      <ReportWatchdog rap={rap} />
+      <Footer>
+        <ReportWatchdog rap={rap} />
+        <PointInfo rap={rap} />
+      </Footer>
     </>
   );
 }

--- a/src/features/rap/PointInfo.tsx
+++ b/src/features/rap/PointInfo.tsx
@@ -1,0 +1,37 @@
+import { Rap } from "gsl-parser";
+import { useParams } from "react-router-dom";
+import { useAppSelector } from "../../hooks";
+import { metersToFeet } from "./cells/Altitude";
+
+interface PointInfoProps {
+  rap: Rap[];
+}
+
+export default function PointInfo({ rap }: PointInfoProps) {
+  const { lat, lon } = useParams();
+  const elevation = useAppSelector((state) => state.weather.elevation);
+  if (!lat || !lon) throw new Error("lat or lon not defined!");
+
+  const rapHeight = rap[0].data[0].height;
+
+  return (
+    <>
+      <div>
+        <a
+          href={`http://www.openstreetmap.org/?mlat=${rap[0].lat}&mlon=${-rap[0]
+            .lon}&zoom=12&layers=M`}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {rap[0].headerLine.slice(0, -1)}
+        </a>
+      </div>
+      <div>
+        Location elevation:{" "}
+        {Math.round(metersToFeet(elevation || -1)).toLocaleString()}ft.
+        Gridpoint elevation:{" "}
+        {Math.round(metersToFeet(rapHeight)).toLocaleString()}ft
+      </div>
+    </>
+  );
+}

--- a/src/features/rap/ReportElevationDiscrepancy.tsx
+++ b/src/features/rap/ReportElevationDiscrepancy.tsx
@@ -1,0 +1,111 @@
+import styled from "@emotion/styled/macro";
+import { faMountains, faTimes } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { outputP3ColorFromRGB } from "../../helpers/colors";
+import { useAppSelector } from "../../hooks";
+import { metersToFeet } from "./cells/Altitude";
+
+/**
+ * in meters
+ */
+export const ELEVATION_DISCREPANCY_THRESHOLD = 160;
+
+const Container = styled.div`
+  margin: 0 auto;
+  max-width: 900px;
+`;
+
+const WarningMessage = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  margin: 1rem;
+  gap: 1rem;
+  position: relative;
+
+  font-size: 0.9em;
+
+  @media (max-width: 500px) {
+    flex-direction: column;
+    text-align: justify;
+  }
+
+  ${outputP3ColorFromRGB([0, 200, 200])}
+  background: #010f26a0;
+  border-color: #000064;
+  border: 1px solid;
+  border-radius: 1rem;
+`;
+
+const MountainIcon = styled(FontAwesomeIcon)`
+  font-size: 1.5rem;
+`;
+
+const CloseButton = styled.button`
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  width: 1rem;
+  height: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1rem;
+  border: 0;
+  color: inherit;
+
+  @media (max-width: 500px) {
+    position: absolute;
+    top: 0.8rem;
+    right: 1rem;
+  }
+
+  cursor: pointer;
+`;
+
+export default function ReportElevationDiscrepancy() {
+  const rap = useAppSelector((state) => state.rap.rap);
+  const { lat, lon } = useParams();
+  const storageKey = `elevation-alert-closed-${lat},${lon}`;
+  const elevation = useAppSelector((state) => state.weather.elevation);
+  const [closed, setClosed] = useState(!!localStorage.getItem(storageKey));
+
+  function close() {
+    localStorage.setItem(storageKey, "1");
+    setClosed(true);
+    console.log("close");
+  }
+
+  if (closed) return <></>;
+
+  if (!rap || typeof rap !== "object" || typeof elevation !== "number")
+    return <></>;
+
+  const rapHeight = rap[0].data[0].height;
+
+  if (Math.abs(elevation - rapHeight) < ELEVATION_DISCREPANCY_THRESHOLD)
+    return <></>;
+
+  const diffType = rapHeight - elevation > 0 ? "lower" : "higher";
+
+  return (
+    <Container>
+      <WarningMessage>
+        <MountainIcon icon={faMountains} />
+        <div>
+          <strong>Notice</strong> The elevation of your location (
+          {Math.round(metersToFeet(elevation)).toLocaleString()}
+          ft) is significantly {diffType} than the forecast gridpoint (
+          {Math.round(metersToFeet(rapHeight)).toLocaleString()}ft). This often
+          occurs due to nearby hills/mountains. Please be aware that weather
+          data may be innacurate due to local atmospheric conditions that differ
+          from those in the surrounding areas.
+        </div>
+        <CloseButton onClick={close}>
+          <FontAwesomeIcon icon={faTimes} />
+        </CloseButton>
+      </WarningMessage>
+    </Container>
+  );
+}

--- a/src/features/rap/ReportWatchdog.tsx
+++ b/src/features/rap/ReportWatchdog.tsx
@@ -6,27 +6,10 @@ import { usePageVisibility } from "react-page-visibility";
 import { useEffect, useState } from "react";
 import { getRap } from "./rapSlice";
 import formatDistanceToNow from "date-fns/formatDistanceToNow";
-import styled from "@emotion/styled/macro";
 import differenceInMinutes from "date-fns/differenceInMinutes";
 import { getWeather } from "../weather/weatherSlice";
 import { useParams } from "react-router-dom";
 import { Rap } from "gsl-parser";
-
-const Container = styled.div`
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 calc(var(--left-safe-area) + 1rem) 0
-    calc(var(--right-safe-area) + 1rem);
-
-  color: var(--softText);
-  font-size: 0.8em;
-  text-align: right;
-
-  @media (max-width: 700px) {
-    text-align: center;
-  }
-`;
 
 interface ReportWatchdogProps {
   rap: Rap[];
@@ -56,25 +39,28 @@ export default function ReportWatchdog({ rap }: ReportWatchdogProps) {
   }, [lastUpdated, dispatch, rap, lat, lon]);
 
   return (
-    <Container>
-      <span
-        css={{
-          color:
-            rapUpdated &&
-            Math.abs(differenceInMinutes(new Date(rapUpdated), new Date())) > 30
-              ? "red"
-              : undefined,
-        }}
-      >
-        Last updated{" "}
-        {rapUpdated
-          ? formatDistanceToNow(new Date(rapUpdated), {
-              addSuffix: true,
-            })
-          : "never"}
-      </span>
-      <br />
-      Automatically updates every 30 minutes
-    </Container>
+    <>
+      <div>
+        <span
+          css={{
+            color:
+              rapUpdated &&
+              Math.abs(differenceInMinutes(new Date(rapUpdated), new Date())) >
+                30
+                ? "red"
+                : undefined,
+          }}
+        >
+          Last updated{" "}
+          {rapUpdated
+            ? formatDistanceToNow(new Date(rapUpdated), {
+                addSuffix: true,
+              })
+            : "never"}
+        </span>
+        <br />
+        Automatically updates every 30 minutes
+      </div>
+    </>
   );
 }

--- a/src/features/rap/cells/Altitude.tsx
+++ b/src/features/rap/cells/Altitude.tsx
@@ -44,6 +44,6 @@ function AltitudeMSL({ height }: Pick<HeightProps, "height">) {
   );
 }
 
-function metersToFeet(meters: number): number {
+export function metersToFeet(meters: number): number {
   return meters * 3.28084;
 }

--- a/src/features/rap/rapSlice.ts
+++ b/src/features/rap/rapSlice.ts
@@ -111,11 +111,27 @@ export const getRap =
 
       dispatch(rapReceived(rap));
     } catch (error) {
-      dispatch(
-        error instanceof CoordinatesGslError ? rapBadCoordinates() : rapFailed()
-      );
-
       if (!(error instanceof GslError)) throw error;
+
+      if (error instanceof CoordinatesGslError) return tryGFSRap();
+
+      dispatch(rapFailed());
+    }
+
+    async function tryGFSRap() {
+      try {
+        const rap = await rapidRefresh.getRap(lat, lon, "GFS");
+
+        dispatch(rapReceived(rap));
+      } catch (error) {
+        if (!(error instanceof GslError)) throw error;
+
+        dispatch(
+          error instanceof CoordinatesGslError
+            ? rapBadCoordinates()
+            : rapFailed()
+        );
+      }
     }
   };
 

--- a/src/routes/Report.tsx
+++ b/src/routes/Report.tsx
@@ -35,6 +35,9 @@ function ValidParamsReport({ lat, lon }: ValidParamsReportProps) {
   const timeZoneLoading = useAppSelector(
     (state) => state.weather.timeZoneLoading
   );
+  const elevationLoading = useAppSelector(
+    (state) => state.weather.elevationLoading
+  );
 
   useEffect(() => {
     if (!isLatLonTrimmed(lat, lon)) return;
@@ -60,7 +63,7 @@ function ValidParamsReport({ lat, lon }: ValidParamsReportProps) {
     return <Navigate to={`/${getTrimmedCoordinates(+lat, +lon)}`} replace />;
   }
 
-  if (timeZoneLoading) return <Loading />;
+  if (timeZoneLoading || elevationLoading) return <Loading />;
 
   switch (rap) {
     case "pending":
@@ -73,7 +76,7 @@ function ValidParamsReport({ lat, lon }: ValidParamsReportProps) {
         <Error
           icon={Map}
           title="That's an unknown place."
-          description="Contiguous United States locations are only supported."
+          description="There was a problem finding weather data for your location. Try again later."
         />
       );
     default:

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -126,6 +126,34 @@ registerRoute(
   })
 );
 
+// Cache API elevation response
+registerRoute(
+  new RegExp("/api/pqs.*"),
+  new NetworkFirst({
+    cacheName: "apiElevationCache",
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 100,
+        maxAgeSeconds: 60 * 60 * 24 * 7, // 7 Days
+      }),
+    ],
+  })
+);
+
+// Cache backup API elevation response
+registerRoute(
+  new RegExp("/api/googleelevation.*"),
+  new NetworkFirst({
+    cacheName: "apiGoogleElevationCache",
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 100,
+        maxAgeSeconds: 60 * 60 * 24 * 7, // 7 Days
+      }),
+    ],
+  })
+);
+
 // This allows the web app to trigger skipWaiting via
 // registration.waiting.postMessage({type: 'SKIP_WAITING'})
 self.addEventListener("message", (event) => {

--- a/src/services/elevation.ts
+++ b/src/services/elevation.ts
@@ -1,0 +1,51 @@
+import axios from "axios";
+
+/**
+ * Get elevation, in meters
+ *
+ * https://nationalmap.gov/epqs/pqs.php?x=-111.051%20&y=45.685&units=Feet&output=json
+ */
+export async function getElevation({
+  lat,
+  lon,
+}: {
+  lat: number;
+  lon: number;
+}): Promise<number> {
+  let { data } = await axios.get("/api/pqs", {
+    params: {
+      x: lon,
+      y: lat,
+      units: "Meters",
+      output: "json",
+    },
+  });
+
+  const potentialElevation =
+    data?.USGS_Elevation_Point_Query_Service?.Elevation_Query?.Elevation;
+
+  // Failed - outside of the USA or some other reason. Use Google.
+  if (typeof potentialElevation === "number" && potentialElevation !== -1000000)
+    return potentialElevation;
+
+  return await getBackupElevation({ lat, lon });
+}
+
+async function getBackupElevation({
+  lat,
+  lon,
+}: {
+  lat: number;
+  lon: number;
+}): Promise<number> {
+  let { data } = await axios.get("/api/googleelevation", {
+    params: {
+      locations: [lat, lon].join(","),
+    },
+  });
+
+  if (data.status !== "OK")
+    throw new Error("Could not fetch backup elevation for site");
+
+  return data.results[0].elevation;
+}

--- a/src/services/geocode.ts
+++ b/src/services/geocode.ts
@@ -48,7 +48,6 @@ export async function search(q: string): Promise<{ lat: number; lon: number }> {
   let { data } = await axios.get("/api/position/search", {
     params: {
       format: "jsonv2",
-      countrycodes: "us",
       limit: 1,
       q,
     },

--- a/src/services/rapidRefresh.ts
+++ b/src/services/rapidRefresh.ts
@@ -7,7 +7,6 @@ import { getTrimmedCoordinates } from "../helpers/coordinates";
 const API_PATH = "/api/rap";
 
 const BASE_PARAMS = {
-  data_source: "Op40",
   latest: "latest",
   // start_year: 2021,
   // start_month_name: "Aug",
@@ -21,10 +20,15 @@ const BASE_PARAMS = {
   start: "latest",
 };
 
-export async function getRap(lat: number, lon: number): Promise<Rap[]> {
+export async function getRap(
+  lat: number,
+  lon: number,
+  data_source: "Op40" | "GFS" = "Op40"
+): Promise<Rap[]> {
   const { data: asciiReports } = await axios.get<string>(API_PATH, {
     params: {
       ...BASE_PARAMS,
+      data_source,
       airport: getTrimmedCoordinates(+lat, +lon),
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5055,9 +5055,9 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 gsl-parser@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/gsl-parser/-/gsl-parser-2.0.0.tgz#5c6811fc579773af8a3346fb58dfe6f837f33e7a"
-  integrity sha512-25aDrdIGGYi1dy9z0t7jSCxBbnHHaSluSTAd8jedpC1jJVd8MphZYhnsnVvxC6LY1GyoTSZQ5K+3KVzM03ee5w==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/gsl-parser/-/gsl-parser-2.0.2.tgz#2d08eb5666c91c653a3542466f388cc2d3f63207"
+  integrity sha512-WeQY0Wc1YrWHD3gn69O1nBhjNfaruYGss/V/zC+UTRyfrL6aOMbk4sFH+At/CIJtb2lva9LVGWASJmGy5fOfhg==
 
 gzip-size@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
- Fetch elevation from USGS or Google (depending)
- Provides alert when there's an elevation discrepancy
- Shows actual elevation AGL when there's a significant discrepancy
- Explicitly show AGL, MSL in interface
- Explicitly display location and gridpoint elevation, and gridpoint location
- Upgrade gsl-report to fix some bugs/edge cases
- Use `MemoryRouter` when installed to disable page swiping to feel more native