### PR TITLE
fix: history not working due to a failed getDistance function from geolib

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "detect-browser": "^5.3.0",
     "emotion": "^11.0.0",
     "es-toolkit": "^1.45.1",
-    "geolib": "^3.3.4",
     "i18next": "^25.8.18",
     "i18next-browser-languagedetector": "^8.2.1",
     "iso8601-duration": "^2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       es-toolkit:
         specifier: ^1.45.1
         version: 1.45.1
-      geolib:
-        specifier: ^3.3.4
-        version: 3.3.4
       i18next:
         specifier: ^25.8.18
         version: 25.8.18(typescript@5.9.3)
@@ -2392,9 +2389,6 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  geolib@3.3.4:
-    resolution: {integrity: sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -6419,8 +6413,6 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
-
-  geolib@3.3.4: {}
 
   get-caller-file@2.0.5: {}
 

--- a/src/features/user/storage.ts
+++ b/src/features/user/storage.ts
@@ -1,5 +1,6 @@
 import { differenceInDays, differenceInHours } from "date-fns";
 import { getAlertId } from "../../helpers/alert";
+import { getDistance } from "../../helpers/geo";
 import { Alert } from "../alerts/alertsSlice";
 import {
   AltitudeType,
@@ -47,26 +48,6 @@ import {
   MAX_LOCATIONS,
   MAX_DISTANCE_MATCH,
 } from "./constants";
-
-const DEG_TO_RAD = Math.PI / 180;
-const EARTH_RADIUS_METERS = 6371000;
-
-function getDistance(a: UserLocation, b: UserLocation): number {
-  const lat1 = a.lat * DEG_TO_RAD;
-  const lat2 = b.lat * DEG_TO_RAD;
-
-  const dLat = (b.lat - a.lat) * DEG_TO_RAD;
-  const dLon = (b.lon - a.lon) * DEG_TO_RAD;
-
-  const h =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(lat1) *
-      Math.cos(lat2) *
-      Math.sin(dLon / 2) ** 2;
-
-  return 2 * EARTH_RADIUS_METERS *
-    Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
-}
 
 export function getLocations(): UserLocation[] {
   const locations: UserLocation[] = JSON.parse(
@@ -126,12 +107,13 @@ export function findLocation(
   coords: GeolocationCoordinates,
 ): UserLocation | undefined {
   const locations = getLocations();
+  const target = { lat: coords.latitude, lon: coords.longitude };
 
-  locations.sort((a, b) => getDistance(a, coords) - getDistance(b, coords));
+  locations.sort((a, b) => getDistance(a, target) - getDistance(b, target));
 
   if (
     locations.length &&
-    getDistance(locations[0], coords) <= MAX_DISTANCE_MATCH
+    getDistance(locations[0], target) <= MAX_DISTANCE_MATCH
   ) {
     return locations[0];
   }

--- a/src/features/user/storage.ts
+++ b/src/features/user/storage.ts
@@ -1,5 +1,4 @@
 import { differenceInDays, differenceInHours } from "date-fns";
-import getDistance from "geolib/es/getDistance";
 import { getAlertId } from "../../helpers/alert";
 import { Alert } from "../alerts/alertsSlice";
 import {
@@ -48,6 +47,26 @@ import {
   MAX_LOCATIONS,
   MAX_DISTANCE_MATCH,
 } from "./constants";
+
+const DEG_TO_RAD = Math.PI / 180;
+const EARTH_RADIUS_METERS = 6371000;
+
+function getDistance(a: UserLocation, b: UserLocation): number {
+  const lat1 = a.lat * DEG_TO_RAD;
+  const lat2 = b.lat * DEG_TO_RAD;
+
+  const dLat = (b.lat - a.lat) * DEG_TO_RAD;
+  const dLon = (b.lon - a.lon) * DEG_TO_RAD;
+
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) *
+      Math.cos(lat2) *
+      Math.sin(dLon / 2) ** 2;
+
+  return 2 * EARTH_RADIUS_METERS *
+    Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
 
 export function getLocations(): UserLocation[] {
   const locations: UserLocation[] = JSON.parse(

--- a/src/helpers/geo.test.ts
+++ b/src/helpers/geo.test.ts
@@ -1,4 +1,39 @@
-import { isPossiblyWithinUSA } from "./geo";
+import { getDistance, isPossiblyWithinUSA } from "./geo";
+
+describe("getDistance", () => {
+  it("returns 0 for identical coordinates", () => {
+    const p = { lat: 40.7128, lon: -74.006 };
+    expect(getDistance(p, p)).toBe(0);
+  });
+
+  it("computes a known great-circle distance within 0.5%", () => {
+    // New York City -> Los Angeles, ~3,936 km
+    const meters = getDistance(
+      { lat: 40.7128, lon: -74.006 },
+      { lat: 34.0522, lon: -118.2437 },
+    );
+    expect(meters).toBeGreaterThan(3_920_000);
+    expect(meters).toBeLessThan(3_955_000);
+  });
+
+  it("is symmetric", () => {
+    const paris = { lat: 48.8566, lon: 2.3522 };
+    const london = { lat: 51.5074, lon: -0.1278 };
+    expect(getDistance(paris, london)).toBeCloseTo(
+      getDistance(london, paris),
+      6,
+    );
+  });
+
+  it("handles tiny deltas without NaN", () => {
+    const meters = getDistance(
+      { lat: 0, lon: 0 },
+      { lat: 0.0001, lon: 0.0001 },
+    );
+    expect(Number.isFinite(meters)).toBe(true);
+    expect(meters).toBeGreaterThan(0);
+  });
+});
 
 describe("isPossiblyWithinUSA", () => {
   describe("should return true", () => {

--- a/src/helpers/geo.ts
+++ b/src/helpers/geo.ts
@@ -1,3 +1,28 @@
+const DEG_TO_RAD = Math.PI / 180;
+const EARTH_RADIUS_METERS = 6371000;
+
+export interface LatLon {
+  lat: number;
+  lon: number;
+}
+
+/**
+ * Great-circle distance between two points (in meters), using the
+ * haversine formula.
+ */
+export function getDistance(a: LatLon, b: LatLon): number {
+  const phi1 = a.lat * DEG_TO_RAD;
+  const phi2 = b.lat * DEG_TO_RAD;
+  const dPhi = (b.lat - a.lat) * DEG_TO_RAD;
+  const dLambda = (b.lon - a.lon) * DEG_TO_RAD;
+
+  const h =
+    Math.sin(dPhi / 2) ** 2 +
+    Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLambda / 2) ** 2;
+
+  return 2 * EARTH_RADIUS_METERS * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+}
+
 export function isPossiblyWithinUSA(
   latitude: number,
   longitude: number,


### PR DESCRIPTION
I fixed this by removing the package all together and simply adding a haversine distance formula. Tested and don't find any issue of locations being added to the list twice which seemed to be the goal of this distance check.